### PR TITLE
feat: 8 improvements — i18n autoSaveRestore, focus/blur API, whole-word search, paste limit, mention onError, image resize min

### DIFF
--- a/src/js/Context.js
+++ b/src/js/Context.js
@@ -339,10 +339,13 @@ export class Context {
 
   /**
    * Returns the current HTML content of the editor.
+   * Zero-width spaces (U+200B) inserted by inline editing helpers are stripped
+   * from the output so they don't leak into the consumer's HTML.
    * @returns {string}
    */
   getHTML() {
-    return this.invoke('editor.getHTML');
+    const html = this.invoke('editor.getHTML');
+    return typeof html === 'string' ? html.replace(/​/g, '') : html;
   }
 
   /**
@@ -543,6 +546,28 @@ export class Context {
       text: el.textContent?.trim() ?? '',
       element: /** @type {HTMLElement} */ (el),
     }));
+  }
+
+  /**
+   * Moves focus into the editable area.
+   */
+  focus() {
+    this.layoutInfo.editable.focus();
+  }
+
+  /**
+   * Removes focus from the editable area.
+   */
+  blur() {
+    this.layoutInfo.editable.blur();
+  }
+
+  /**
+   * Returns true when the editor is currently in fullscreen mode.
+   * @returns {boolean}
+   */
+  isFullscreen() {
+    return this.invoke('fullscreen.isActive') === true;
   }
 
   /**

--- a/src/js/i18n/de.js
+++ b/src/js/i18n/de.js
@@ -325,4 +325,11 @@ export const de = {
     imageSize: (maxSize) =>
       `Die Bilddatei ist zu groß. Die maximal zulässige Größe beträgt ${maxSize} MB.`,
   },
+
+  autoSaveRestore: {
+    found:   'Entwurf gefunden. Wiederherstellen?',
+    foundAt: 'Entwurf vom {date}. Wiederherstellen?',
+    restore: 'Wiederherstellen',
+    discard: 'Verwerfen',
+  },
 };

--- a/src/js/i18n/en.js
+++ b/src/js/i18n/en.js
@@ -153,6 +153,7 @@ export const en = {
     findPlaceholder:  'Find\u2026',
     searchAriaLabel:  'Search text',
     caseSensitive:    '\u00a0Case sensitive',
+    wholeWord:        'Whole Word',
     prevBtn:          '\u2190 Prev',
     nextBtn:          'Next \u2192',
     replacePlaceholder: 'Replace with\u2026',
@@ -162,6 +163,13 @@ export const en = {
     noResults:          'No results',
     useRegex:           'Use Regular Expression',
     close:              '\u00d7',
+  },
+
+  autoSaveRestore: {
+    found:   'Draft found. Restore?',
+    foundAt: 'Draft from {date}. Restore?',
+    restore: 'Restore',
+    discard: 'Discard',
   },
 
   shortcutsDialog: {

--- a/src/js/i18n/es.js
+++ b/src/js/i18n/es.js
@@ -325,4 +325,11 @@ export const es = {
     imageSize: (maxSize) =>
       `El archivo de imagen es demasiado grande. El tamaño máximo permitido es ${maxSize} MB.`,
   },
+
+  autoSaveRestore: {
+    found:   'Borrador encontrado. ¿Restaurar?',
+    foundAt: 'Borrador del {date}. ¿Restaurar?',
+    restore: 'Restaurar',
+    discard: 'Descartar',
+  },
 };

--- a/src/js/i18n/fr.js
+++ b/src/js/i18n/fr.js
@@ -326,4 +326,11 @@ export const fr = {
     imageSize: (maxSize) =>
       `Le fichier image est trop volumineux. La taille maximale autorisée est de ${maxSize}\u00a0Mo.`,
   },
+
+  autoSaveRestore: {
+    found:   'Brouillon trouvé. Restaurer ?',
+    foundAt: 'Brouillon du {date}. Restaurer ?',
+    restore: 'Restaurer',
+    discard: 'Ignorer',
+  },
 };

--- a/src/js/i18n/ja.js
+++ b/src/js/i18n/ja.js
@@ -326,4 +326,11 @@ export const ja = {
     imageSize: (maxSize) =>
       `画像ファイルが大きすぎます。最大許容サイズは ${maxSize} MB です。`,
   },
+
+  autoSaveRestore: {
+    found:   '下書きが見つかりました。復元しますか？',
+    foundAt: '{date} の下書きが見つかりました。復元しますか？',
+    restore: '復元',
+    discard: '破棄',
+  },
 };

--- a/src/js/i18n/ko.js
+++ b/src/js/i18n/ko.js
@@ -325,4 +325,11 @@ export const ko = {
     imageSize: (maxSize) =>
       `이미지 파일이 너무 큽니다. 최대 허용 크기는 ${maxSize} MB입니다.`,
   },
+
+  autoSaveRestore: {
+    found:   '초안을 찾았습니다. 복원하시겠습니까?',
+    foundAt: '{date}의 초안을 찾았습니다. 복원하시겠습니까?',
+    restore: '복원',
+    discard: '삭제',
+  },
 };

--- a/src/js/i18n/vi.js
+++ b/src/js/i18n/vi.js
@@ -328,4 +328,11 @@ export const vi = {
     imageSize: (maxSize) =>
       `Tệp hình ảnh quá lớn. Kích thước tối đa cho phép là ${maxSize} MB.`,
   },
+
+  autoSaveRestore: {
+    found:   'Tìm thấy bản nháp. Khôi phục?',
+    foundAt: 'Bản nháp từ {date}. Khôi phục?',
+    restore: 'Khôi phục',
+    discard: 'Bỏ qua',
+  },
 };

--- a/src/js/i18n/zh.js
+++ b/src/js/i18n/zh.js
@@ -326,4 +326,11 @@ export const zh = {
     imageSize: (maxSize) =>
       `图片文件过大。最大允许大小为 ${maxSize} MB。`,
   },
+
+  autoSaveRestore: {
+    found:   '找到草稿。是否恢复？',
+    foundAt: '发现 {date} 的草稿。是否恢复？',
+    restore: '恢复',
+    discard: '放弃',
+  },
 };

--- a/src/js/module/Clipboard.js
+++ b/src/js/module/Clipboard.js
@@ -187,6 +187,18 @@ export class Clipboard {
     const forcePlain = this._forcePlain;
     this._forcePlain = false;
 
+    // Enforce maxPasteSize limit (default 5 MB)
+    const maxBytes = (this.options.maxPasteSize ?? 5) * 1024 * 1024;
+    if (maxBytes > 0) {
+      const text = clipboardData.getData('text/plain') || '';
+      const html = clipboardData.getData('text/html') || '';
+      const size = Math.max(text.length, html.length);
+      if (size > maxBytes) {
+        event.preventDefault();
+        return;
+      }
+    }
+
     // 1. Image file in clipboard (screenshot, copy-image-from-browser, etc.)
     if (clipboardData.items) {
       const imageItems = Array.from(clipboardData.items).filter(

--- a/src/js/module/FindReplace.js
+++ b/src/js/module/FindReplace.js
@@ -31,6 +31,7 @@ export class FindReplace extends BaseDialog {
     this._currentIndex = -1;
     this._caseSensitive = false;
     this._useRegex = false;
+    this._wholeWord = false;
     /** @type {'find'|'replace'} */
     this._mode = 'find';
 
@@ -39,6 +40,7 @@ export class FindReplace extends BaseDialog {
     this._lastQuery = null;
     this._lastCaseSensitive = null;
     this._lastUseRegex = null;
+    this._lastWholeWord = null;
 
     this._focusTimer = null;
   }
@@ -179,6 +181,14 @@ export class FindReplace extends BaseDialog {
     });
     regexBtn.textContent = '.*';
 
+    const wholeWordBtn = createElement('button', {
+      type: 'button',
+      class: 'an-fr-icon-btn',
+      title: L.wholeWord,
+      'aria-label': L.wholeWord,
+    });
+    wholeWordBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="7" width="18" height="10" rx="2"/><line x1="7" y1="21" x2="7" y2="17"/><line x1="17" y1="21" x2="17" y2="17"/></svg>`;
+
     const prevBtn = createElement('button', {
       type: 'button',
       class: 'an-fr-icon-btn',
@@ -198,7 +208,7 @@ export class FindReplace extends BaseDialog {
     const counter = createElement('span', { class: 'an-fr-counter' });
     this._counterEl = counter;
 
-    searchBar.append(findInput, caseCheckbox, caseBtn, regexBtn, prevBtn, nextBtn, counter);
+    searchBar.append(findInput, caseCheckbox, caseBtn, regexBtn, wholeWordBtn, prevBtn, nextBtn, counter);
     box.appendChild(searchBar);
 
     // ---- Replace row: [input] [Replace] [All]  (hidden by default) ----
@@ -266,7 +276,14 @@ export class FindReplace extends BaseDialog {
       this._lastQuery = null;
       this._onSearch();
     });
-    this._disposers.push(d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, dRegex);
+    const dWholeWord = on(wholeWordBtn, 'click', () => {
+      this._wholeWord = !this._wholeWord;
+      wholeWordBtn.classList.toggle('an-fr-icon-btn--active', this._wholeWord);
+      this._queryRegex = null;
+      this._lastQuery = null;
+      this._onSearch();
+    });
+    this._disposers.push(d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, dRegex, dWholeWord);
 
     return overlay;
   }
@@ -341,13 +358,14 @@ export class FindReplace extends BaseDialog {
    */
   _findRawMatches(query, root) {
     const results = [];
-    // Reuse compiled regex when query, case-sensitivity, and regex mode haven't changed
-    if (this._lastQuery !== query || this._lastCaseSensitive !== this._caseSensitive || this._lastUseRegex !== this._useRegex) {
+    // Reuse compiled regex when query, case-sensitivity, regex mode, and whole-word haven't changed
+    if (this._lastQuery !== query || this._lastCaseSensitive !== this._caseSensitive || this._lastUseRegex !== this._useRegex || this._lastWholeWord !== this._wholeWord) {
       const flags = this._caseSensitive ? 'g' : 'gi';
       try {
-        const pattern = this._useRegex
+        let pattern = this._useRegex
           ? query
           : query.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+        if (this._wholeWord) pattern = `\\b${pattern}\\b`;
         this._queryRegex = new RegExp(pattern, flags);
       } catch (_) {
         this._queryRegex = null;
@@ -355,6 +373,7 @@ export class FindReplace extends BaseDialog {
       this._lastQuery = query;
       this._lastCaseSensitive = this._caseSensitive;
       this._lastUseRegex = this._useRegex;
+      this._lastWholeWord = this._wholeWord;
     }
     if (!this._queryRegex) return results;
     const re = this._queryRegex;

--- a/src/js/module/ImageResizer.js
+++ b/src/js/module/ImageResizer.js
@@ -204,6 +204,7 @@ export class ImageResizer {
     const isCorner = pos.length === 2; // 'nw','ne','se','sw'
 
     const editable = this.context.layoutInfo.editable;
+    const minSz = this.context.options?.minImageSize ?? 20;
     let _raf = null; // rAF handle — ensures at most one write per paint frame
 
     const onMove = (me) => {
@@ -218,19 +219,19 @@ export class ImageResizer {
         let newW = startW;
         let newH = startH;
 
-        if (pos.includes('e')) newW = Math.max(20, startW + dx);
-        if (pos.includes('w')) newW = Math.max(20, startW - dx);
-        if (pos.includes('s')) newH = Math.max(20, startH + dy);
-        if (pos.includes('n')) newH = Math.max(20, startH - dy);
+        if (pos.includes('e')) newW = Math.max(minSz, startW + dx);
+        if (pos.includes('w')) newW = Math.max(minSz, startW - dx);
+        if (pos.includes('s')) newH = Math.max(minSz, startH + dy);
+        if (pos.includes('n')) newH = Math.max(minSz, startH - dy);
 
         newW = Math.min(newW, maxW);
 
         if (isCorner) {
           if (Math.abs(dx) >= Math.abs(dy)) {
-            newH = Math.max(20, Math.round(newW / aspectRatio));
+            newH = Math.max(minSz, Math.round(newW / aspectRatio));
           } else {
-            newW = Math.min(Math.max(20, Math.round(newH * aspectRatio)), maxW);
-            newH = Math.max(20, Math.round(newW / aspectRatio));
+            newW = Math.min(Math.max(minSz, Math.round(newH * aspectRatio)), maxW);
+            newH = Math.max(minSz, Math.round(newW / aspectRatio));
           }
         }
 

--- a/src/js/module/Mention.js
+++ b/src/js/module/Mention.js
@@ -279,7 +279,10 @@ export class Mention {
       };
       const result = this._cfg.onSearch(this._query, cb);
       if (result && typeof result.then === 'function') {
-        result.then(cb).catch(() => this._hideDropdown());
+        result.then(cb).catch((err) => {
+          this._hideDropdown();
+          if (typeof this._cfg.onError === 'function') this._cfg.onError(err);
+        });
       }
     }, this._cfg.debounce);
   }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -119,6 +119,10 @@ export interface AsnOptions {
   autoSaveRestoreTimeout?: number;
   /** Callback fired after the user chooses to restore a draft. */
   onAutoSaveRestore?: (html: string, context: Context) => void;
+  /** Maximum paste size in MB before paste is silently dropped (0 = unlimited). Default: 5. */
+  maxPasteSize?: number;
+  /** Minimum image dimension in px during resize (width and height). Default: 20. */
+  minImageSize?: number;
 
   // ---- Markdown input shortcuts (#3) ----------------------------------------
 
@@ -165,6 +169,8 @@ export interface MentionOptions {
    * - Promise:  `async onSearch(query) { return items; }`
    */
   onSearch: (query: string, callback: (items: MentionItem[]) => void) => void | Promise<MentionItem[]>;
+  /** Called when onSearch rejects with an error (Promise style only). */
+  onError?: (error: unknown) => void;
   /** Optional. Return custom HTML string for the inserted chip, or null to use the default. */
   onInsert?: (item: MentionItem) => string | null;
   /** CSS class added to the inserted mention chip. Default: 'an-mention'. */
@@ -309,6 +315,12 @@ export interface AsnLocale {
     imageFormat: (type: string) => string;
     imageSize: (maxMb: number) => string;
   };
+  autoSaveRestore: {
+    found: string;
+    foundAt: string;
+    restore: string;
+    discard: string;
+  };
 }
 
 /** Registry of all built-in locales (keys: 'en', 'vi', 'ja', 'zh', 'fr'). */
@@ -422,6 +434,18 @@ export declare class Context {
 
   /** Downloads the editor content as a Markdown file. */
   downloadMarkdown(filename?: string): void;
+
+  /** Moves keyboard focus into the editable area. */
+  focus(): void;
+
+  /** Removes keyboard focus from the editable area. */
+  blur(): void;
+
+  /** Returns true when the editor is currently in fullscreen mode. */
+  isFullscreen(): boolean;
+
+  /** Opens a print dialog with the editor content. */
+  print(title?: string): void;
 
   /** Enables or disables (read-only) mode on this instance. */
   setDisabled(disabled: boolean): void;


### PR DESCRIPTION
## Summary

- **i18n**: Add `autoSaveRestore` keys (`found`, `foundAt`, `restore`, `discard`) to all 8 locales — fixes hardcoded English fallback strings in `AutoSaveRestore.js`
- **Context API**: Add `focus()`, `blur()`, `isFullscreen()` convenience methods
- **Context API**: Strip zero-width spaces (U+200B) from `getHTML()` output
- **FindReplace**: Add whole-word matching toggle button (`\b...\b`)
- **Clipboard**: Add `maxPasteSize` option (default 5 MB) to silently drop oversized pastes
- **Mention**: Add `onError` callback for Promise-based `onSearch` rejection
- **ImageResizer**: Read `minImageSize` from options (default 20px) instead of hardcoded value
- **types/index.d.ts**: Add `print()`, `focus()`, `blur()`, `isFullscreen()` to `Context`; add `maxPasteSize`, `minImageSize` to `AsnOptions`; add `onError` to `MentionOptions`; add `autoSaveRestore` to `AsnLocale`

## Test plan

- [ ] All coverage thresholds pass: lines ≥88%, statements ≥84%, functions ≥80%, branches ≥70%
- [ ] AutoSaveRestore banner shows translated text in vi/ja/zh/fr/de/es/ko locales
- [ ] `ctx.focus()` / `ctx.blur()` move keyboard focus in/out of editor
- [ ] `ctx.isFullscreen()` returns `true` when fullscreen is active
- [ ] `ctx.getHTML()` does not contain zero-width space characters
- [ ] Whole-word toggle `W` button in Find bar — "word" matches only standalone word, not "password"
- [ ] Paste size limit: pasting content > 5 MB is silently rejected
- [ ] Promise-based `onSearch` rejection calls `onError` callback
- [ ] Image resize minimum respects `minImageSize` option
- [ ] `npm run typecheck` passes with new type declarations

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_