### PR TITLE
docs: document missing Context API methods + table sort indicator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,9 @@ context.on('eventName', callback)           // subscribe to editor events
 
 ### Module Inventory (`src/js/module/`)
 
-28 modules split by responsibility:
+29 modules split by responsibility:
 - **Core UI**: `Editor`, `Toolbar`, `Buttons`, `Statusbar`
-- **Dialogs**: `LinkDialog`, `ImageDialog`, `VideoDialog`, `EmojiDialog`, `IconDialog`, `FindReplace`, `ShortcutsDialog`
+- **Dialogs**: `BaseDialog`, `LinkDialog`, `ImageDialog`, `VideoDialog`, `EmojiDialog`, `IconDialog`, `FindReplace`, `ShortcutsDialog`
 - **Floating toolbars**: `LinkTooltip`, `ImageTooltip`, `VideoTooltip`, `TableTooltip`, `CodeTooltip`, `BubbleToolbar`
 - **Editing behaviors**: `Clipboard`, `ContextMenu`, `MarkdownShortcuts`, `Codeview`, `Fullscreen`, `ImageResizer`, `ImageCropOverlay`, `VideoResizer`
 - **UX**: `Placeholder`, `AutoSaveRestore`, `Mention`

--- a/README.md
+++ b/README.md
@@ -406,6 +406,15 @@ See the [full Plugin API docs →](https://cmm-cmm.github.io/Autumn-Note/docs.ht
 | `editor.getHTML()` | Returns the current HTML. Zero-width spaces from the icon picker are stripped automatically. |
 | `editor.setHTML(html)` | Sets HTML content (sanitised). `<iframe>` elements are preserved. |
 | `editor.getText()` | Returns plain text with no markup. |
+| `editor.setText(text)` | Replaces the content with plain text (escaped, no markup). |
+| `editor.getMarkdown()` | Returns the current content converted to Markdown. |
+| `editor.setMarkdown(md)` | Replaces the content, converting the given Markdown to HTML. |
+| `editor.insertHTML(html)` | Inserts sanitised HTML at the current cursor position. |
+| `editor.insertText(text)` | Inserts plain text at the current cursor position. |
+| `editor.downloadHTML(filename?)` | Downloads the current content as an `.html` file (default `document.html`). |
+| `editor.downloadText(filename?)` | Downloads the current content as a `.txt` file (default `document.txt`). |
+| `editor.downloadMarkdown(filename?)` | Downloads the current content as a `.md` file (default `document.md`). |
+| `editor.print(title?)` | Opens the browser print dialog with the current content in a clean printable layout. |
 | `editor.clear()` | Clears all content, resets to an empty `<p>`. |
 | `editor.clearHistory()` | Resets the undo/redo stack. |
 | `editor.getUndoCount()` | Returns the number of available undo steps. |
@@ -414,6 +423,9 @@ See the [full Plugin API docs →](https://cmm-cmm.github.io/Autumn-Note/docs.ht
 | `editor.getCharCount()` | Returns the current character count. |
 | `editor.getTableOfContents()` | Returns an array of `{ level, text, element }` heading objects. |
 | `editor.setDisabled(bool)` | Disables (`true`) or re-enables (`false`) the editor and toolbar. |
+| `editor.focus()` | Moves keyboard focus to the editable area. |
+| `editor.blur()` | Removes keyboard focus from the editable area. |
+| `editor.isFullscreen()` | Returns `true` if the editor is currently in fullscreen mode. |
 | `editor.destroy()` | Removes the editor, disposes all modules, and restores the original element. |
 | `editor.on(event, fn)` | Subscribes to an editor event. Returns an unsubscribe function. |
 | `editor.off(event, fn)` | Removes a previously registered listener. |

--- a/src/js/module/Clipboard.js
+++ b/src/js/module/Clipboard.js
@@ -365,7 +365,7 @@ export class Clipboard {
     const mime = /:(.*?);/.exec(header)?.[1] ?? 'image/png';
     const binary = atob(b64);
     const arr = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) arr[i] = binary.codePointAt(i);
+    for (let i = 0; i < binary.length; i++) arr[i] = binary.charCodeAt(i);
     return new Blob([arr], { type: mime });
   }
 

--- a/src/js/module/Mention.js
+++ b/src/js/module/Mention.js
@@ -17,6 +17,7 @@
  *   debounce:     200,
  *   onSearch:     (query, callback) => void,
  *   onInsert:     (item) => string | null,
+ *   onError:      (err: Error) => void,
  *   mentionClass: 'an-mention',
  *   allowSpaces:  false,
  * }

--- a/src/js/module/TableTooltip.js
+++ b/src/js/module/TableTooltip.js
@@ -1470,7 +1470,28 @@ export class TableTooltip {
         : bText.localeCompare(aText);
     });
     rows.forEach((row) => tbody.appendChild(row));
+    this._markSortIndicator(table, colIdx, direction);
     this.context.invoke('editor.afterCommand');
+  }
+
+  /**
+   * Marks the header cell of the sorted column with `an-sort-asc`/`an-sort-desc`
+   * so the active sort column and direction are visible, and clears any previous
+   * indicator. No-op for tables without a `<thead>` (no header row to mark).
+   * @param {HTMLTableElement} table
+   * @param {number} colIdx
+   * @param {'asc'|'desc'} direction
+   */
+  _markSortIndicator(table, colIdx, direction) {
+    const thead = table.querySelector('thead');
+    if (!thead) return;
+    thead.querySelectorAll('.an-sort-asc, .an-sort-desc').forEach((el) => {
+      el.classList.remove('an-sort-asc', 'an-sort-desc');
+    });
+    const headerRow = thead.querySelector('tr');
+    if (!headerRow) return;
+    const headerCell = getCellAtVisualCol(headerRow, colIdx);
+    if (headerCell) headerCell.classList.add(direction === 'asc' ? 'an-sort-asc' : 'an-sort-desc');
   }
 
   _exportTableCSV() {

--- a/src/styles/autumnnote.scss
+++ b/src/styles/autumnnote.scss
@@ -565,6 +565,17 @@
     th {
       background: $an-bg-toolbar;
       font-weight: 600;
+
+      // Sort indicator — shows the active sorted column and direction
+      &.an-sort-asc::after,
+      &.an-sort-desc::after {
+        display: inline-block;
+        margin-left: 6px;
+        font-size: 0.7em;
+        opacity: 0.6;
+      }
+      &.an-sort-asc::after { content: '\25B2'; }
+      &.an-sort-desc::after { content: '\25BC'; }
     }
   }
 }

--- a/test/module/TableTooltip.test.js
+++ b/test/module/TableTooltip.test.js
@@ -756,6 +756,71 @@ describe('TableTooltip._sortColumn', () => {
   });
 });
 
+// ── Sort indicator ───────────────────────────────────────────────────────────
+
+describe('TableTooltip._markSortIndicator', () => {
+  const THEAD_HTML = `
+  <table class="an-table">
+    <thead>
+      <tr><th>Name</th><th>Score</th></tr>
+    </thead>
+    <tbody>
+      <tr><td>Banana</td><td>3</td></tr>
+      <tr><td>Apple</td><td>10</td></tr>
+      <tr><td>Cherry</td><td>1</td></tr>
+    </tbody>
+  </table>`;
+
+  const selectCell = (cell) => {
+    const r = document.createRange();
+    r.setStart(cell.firstChild, 0);
+    r.collapse(true);
+    window.getSelection().removeAllRanges();
+    window.getSelection().addRange(r);
+  };
+
+  it('marks the sorted column header and toggles direction on repeat sorts', () => {
+    const { tt, ctx } = makeTooltip(THEAD_HTML);
+    const table = activateTable(tt, ctx);
+    const headers = table.querySelectorAll('thead th');
+
+    selectCell(table.querySelector('tbody td'));
+    tt._sortColumn('asc');
+    expect(headers[0].classList.contains('an-sort-asc')).toBe(true);
+    expect(headers[0].classList.contains('an-sort-desc')).toBe(false);
+
+    selectCell(table.querySelector('tbody td'));
+    tt._sortColumn('desc');
+    expect(headers[0].classList.contains('an-sort-desc')).toBe(true);
+    expect(headers[0].classList.contains('an-sort-asc')).toBe(false);
+  });
+
+  it('clears the indicator from the previous column when sorting a different column', () => {
+    const { tt, ctx } = makeTooltip(THEAD_HTML);
+    const table = activateTable(tt, ctx);
+    const headers = table.querySelectorAll('thead th');
+
+    selectCell(table.querySelector('tbody td'));
+    tt._sortColumn('asc');
+    expect(headers[0].classList.contains('an-sort-asc')).toBe(true);
+
+    selectCell(table.querySelectorAll('tbody td')[1]);
+    tt._sortColumn('desc');
+    expect(headers[0].classList.contains('an-sort-asc')).toBe(false);
+    expect(headers[1].classList.contains('an-sort-desc')).toBe(true);
+  });
+
+  it('does not add an indicator when the table has no thead', () => {
+    const noThead = `<table class="an-table"><tbody><tr><td>B</td></tr><tr><td>A</td></tr></tbody></table>`;
+    const { tt, ctx } = makeTooltip(noThead);
+    const table = activateTable(tt, ctx);
+
+    selectCell(table.querySelector('tbody td'));
+    tt._sortColumn('asc');
+    expect(table.querySelector('.an-sort-asc, .an-sort-desc')).toBeNull();
+  });
+});
+
 // ── Export CSV ────────────────────────────────────────────────────────────────
 
 describe('TableTooltip._exportTableCSV', () => {


### PR DESCRIPTION
## Summary

Follow-up từ một đợt re-audit toàn project (post v1.8.0). Hầu hết các đề xuất từ audit trước đã được implement; PR này giải quyết các mục còn tồn đọng đã được verify là thật:

- **README.md**: bổ sung 12 method còn thiếu trong bảng "Context (instance methods)" — `setText`, `getMarkdown`/`setMarkdown`, `insertHTML`/`insertText`, `downloadHTML`/`downloadText`/`downloadMarkdown`, `print`, `focus`, `blur`, `isFullscreen`. Tất cả đã có trong `Context.js` và `types/index.d.ts` nhưng chưa được document.
- **CLAUDE.md**: sửa số lượng module (28 → 29) và thêm `BaseDialog` vào module inventory (Dialogs).
- **Mention.js**: bổ sung `onError` vào JSDoc "Options shape" comment (đã implement, chỉ thiếu doc).
- **Clipboard.js**: đổi `codePointAt` → `charCodeAt` trong `_dataUrlToBlob` cho đúng ngữ nghĩa khi đọc byte từ `atob()` output (không đổi hành vi, vì output của `atob()` luôn trong range 0x00-0xFF).
- **TableTooltip**: thêm chỉ báo trực quan (`an-sort-asc`/`an-sort-desc`) trên header cell của cột đang sort, tự xoá khi sort cột khác. Style mới trong `autumnnote.scss`. No-op cho table không có `<thead>`.

Các finding khác từ audit (Excel paste markers, AutoSaveRestore JSON.parse, ContextMenu/BubbleToolbar edge cases, keyboard navigation roving-tabindex, v.v.) đã được review và xác định là không cần hành động hoặc nằm ngoài scope (xem ghi chú trong session).

## Test plan
- [x] `npx vitest run` — 1598/1598 tests pass (thêm 3 test mới cho sort indicator)
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm run build` — biên dịch SCSS thành công, verify class `an-sort-asc`/`an-sort-desc` có trong `dist/autumnnote.css`

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_