### PR TITLE
feat(build): configurable demo base path/output dir for Cloudflare /demo subpath

### DIFF
--- a/vite.demo.config.js
+++ b/vite.demo.config.js
@@ -1,15 +1,23 @@
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
+// DEMO_BASE_PATH / DEMO_OUT_DIR let this same config target either GitHub
+// Pages (default, served at /Autumn-Note/) or a /demo/ subpath on another
+// host (e.g. Cloudflare Pages), where the build output must physically live
+// under a `demo/` folder matching the `base` prefix.
+const base = process.env.DEMO_BASE_PATH || '/Autumn-Note/';
+const outDir = process.env.DEMO_OUT_DIR
+  ? resolve(__dirname, process.env.DEMO_OUT_DIR)
+  : resolve(__dirname, '_site');
+
 export default defineConfig({
-  // Must match the GitHub Pages repo sub-path
-  base: '/Autumn-Note/',
+  base,
   // Demo site source lives in demo/ — keep build output flat at _site/
   // so published URLs (/, /docs.html, /playground.html) stay unchanged.
   root: resolve(__dirname, 'demo'),
   publicDir: resolve(__dirname, 'public'),
   build: {
-    outDir: resolve(__dirname, '_site'),
+    outDir,
     emptyOutDir: true,
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- Cho phép build demo site cho subpath `/demo/` (vd. khi nhúng vào một site lớn hơn trên Cloudflare Pages) thay vì cố định `/Autumn-Note/` (GitHub Pages).
- `vite.demo.config.js` đọc `DEMO_BASE_PATH` (default `/Autumn-Note/`) và `DEMO_OUT_DIR` (default `_site`) từ env — không đổi hành vi mặc định của `npm run build:demo` / CI hiện tại.

## Cách dùng cho Cloudflare (`/demo/` subpath)
```bash
DEMO_BASE_PATH=/demo/ DEMO_OUT_DIR=_site/demo npm run build:demo
```
Kết quả: `_site/demo/index.html`, `_site/demo/docs.html`, `_site/demo/playground.html`,
`_site/demo/assets/*`, `_site/demo/image/*` — tất cả asset URL trong HTML đều
được prefix `/demo/` đúng. Trong project Cloudflare Pages của site lớn, copy
`_site/demo` vào output directory của site đó dưới đường dẫn `demo/`.

## Test plan
- [x] `npm run build:demo` (default) → `_site/index.html` vẫn dùng prefix `/Autumn-Note/` như cũ
- [x] `DEMO_BASE_PATH=/demo/ DEMO_OUT_DIR=_site/demo npm run build:demo` → output đúng cấu trúc `demo/` với prefix `/demo/`
- [x] `npm run lint` / `npm run typecheck` — clean

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_