### PR TITLE
Dev

### DIFF
--- a/vite.demo.config.js
+++ b/vite.demo.config.js
@@ -1,15 +1,23 @@
 import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
+// DEMO_BASE_PATH / DEMO_OUT_DIR let this same config target either GitHub
+// Pages (default, served at /Autumn-Note/) or a /demo/ subpath on another
+// host (e.g. Cloudflare Pages), where the build output must physically live
+// under a `demo/` folder matching the `base` prefix.
+const base = process.env.DEMO_BASE_PATH || '/Autumn-Note/';
+const outDir = process.env.DEMO_OUT_DIR
+  ? resolve(__dirname, process.env.DEMO_OUT_DIR)
+  : resolve(__dirname, '_site');
+
 export default defineConfig({
-  // Must match the GitHub Pages repo sub-path
-  base: '/Autumn-Note/',
+  base,
   // Demo site source lives in demo/ — keep build output flat at _site/
   // so published URLs (/, /docs.html, /playground.html) stay unchanged.
   root: resolve(__dirname, 'demo'),
   publicDir: resolve(__dirname, 'public'),
   build: {
-    outDir: resolve(__dirname, '_site'),
+    outDir,
     emptyOutDir: true,
     rollupOptions: {
       input: {


### PR DESCRIPTION
Merge `dev` into `main`: configurable demo base path/output dir for Cloudflare `/demo/` subpath builds (#29).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_