### PR TITLE
fix(sonar): use sonar.cpd.exclusions for i18n files on dev

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,11 +1,10 @@
 sonar.projectKey=cmm-cmm_Autumn-Note
 sonar.organization=cmm-cmm
 
-# Exclude generated build outputs and i18n locale files from all analysis.
-# i18n files are excluded from CPD because identical key names across 8 locales
-# are structurally unavoidable and not meaningful duplication.
-sonar.exclusions=_site/**,dist/**,src/js/i18n/**
+# Exclude generated build outputs from all analysis
+sonar.exclusions=_site/**,dist/**
 
-# Exclude HTML pages and test files from Copy-Paste Detection only.
+# Exclude HTML pages, test files, and i18n locale files from Copy-Paste Detection.
 # HTML pages share structural markup by design; test boilerplate is intentional.
-sonar.cpd.exclusions=*.html,test/**
+# i18n files share identical key names across 8 locales by design — not real duplication.
+sonar.cpd.exclusions=*.html,test/**,src/js/i18n/**


### PR DESCRIPTION
## Summary

- Replaces `sonar.exclusions` i18n entry with `sonar.cpd.exclusions` for `src/js/i18n/**`
- Fixes the stubborn 51.5% false-positive duplication on PR #34

## Root cause

`sonar.exclusions` in SonarCloud's automatic analysis mode does not suppress the **Duplication on New Code** Quality Gate. `sonar.cpd.exclusions` is the correct property for Copy-Paste Detection scope. The i18n locale files share identical key names across 8 languages by design — flagging this as duplication is a false positive.

## Test plan

- [ ] Merge this PR to `dev`
- [ ] Push a commit to PR #34's branch to trigger re-analysis
- [ ] SonarCloud Quality Gate on PR #34 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_