### PR TITLE
fix(sonar): add i18n locale files to sonar.cpd.exclusions on main

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,6 +4,7 @@ sonar.organization=cmm-cmm
 # Exclude generated build outputs from all analysis
 sonar.exclusions=_site/**,dist/**
 
-# Exclude HTML pages and test files from Copy-Paste Detection only.
+# Exclude HTML pages, test files, and i18n locale files from Copy-Paste Detection.
 # HTML pages share structural markup by design; test boilerplate is intentional.
-sonar.cpd.exclusions=*.html,test/**
+# i18n files share identical key names across 8 locales by design — not real duplication.
+sonar.cpd.exclusions=*.html,test/**,src/js/i18n/**


### PR DESCRIPTION
## Summary

- Adds `src/js/i18n/**` to `sonar.cpd.exclusions` in `sonar-project.properties`
- Fixes the persistent 51.5% false-positive duplication Quality Gate failure on PR #34

## Root cause (confirmed after multiple investigations)

SonarCloud's automatic analysis (GitHub App) reads `sonar-project.properties` from the **default branch** (`main`), not from `dev` or the PR branch. Previous attempts to fix this on `dev` and the PR branch had no effect because the config was being read from here (`main`) all along.

The i18n locale files (`src/js/i18n/*.js`) share identical property key names across 8 languages by design — this is not real code duplication.

## Test plan

- [ ] Merge this PR to `main`
- [ ] Push a commit to PR #34's branch to trigger SonarCloud re-analysis
- [ ] Quality Gate passes (duplication drops from 51.5% → 0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration to expand detection exclusions for localization files, improving code quality scanning accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->