### PR TITLE
chore(types): update built-in locale list from 5 to 8 languages

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -106,7 +106,7 @@ export interface AsnOptions {
   colorSwatches?: string[];
   /**
    * Display language for the editor UI.
-   * Built-in: 'en' (default) | 'vi' | 'ja' | 'zh' | 'fr'.
+   * Built-in: 'en' (default) | 'vi' | 'ja' | 'zh' | 'fr' | 'de' | 'es' | 'ko'.
    * Pass a partial locale object to override individual strings.
    */
   lang?: string | Partial<AsnLocale>;
@@ -323,7 +323,7 @@ export interface AsnLocale {
   };
 }
 
-/** Registry of all built-in locales (keys: 'en', 'vi', 'ja', 'zh', 'fr'). */
+/** Registry of all built-in locales (keys: 'en', 'vi', 'ja', 'zh', 'fr', 'de', 'es', 'ko'). */
 export declare const locales: Record<string, AsnLocale>;
 
 /**


### PR DESCRIPTION
## Summary

- Updates the JSDoc comment on the `lang` option in `types/index.d.ts` from listing 5 built-in languages to all 8: adds `'de'`, `'es'`, `'ko'`
- Updates the `locales` registry declaration comment to match
- German, Spanish, and Korean locales were added in v1.6.x but the type comments were not updated at the time (plan item C1)

## Test plan
- [ ] `npm run typecheck` passes (no regressions)
- [ ] `npm test` — 1599/1599 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_