### PR TITLE
ci: add test gate to publish and lint/typecheck to pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm typecheck
+
       - name: Run tests with coverage
         run: pnpm test:coverage
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Run tests
+        run: pnpm test
+
       - name: Verify npm auth
         run: |
           if [ -z "$NODE_AUTH_TOKEN" ]; then

--- a/src/styles/autumnnote.scss
+++ b/src/styles/autumnnote.scss
@@ -31,9 +31,13 @@
 
   &.an-focused {
     border-color: var(--an-focus-color, #{$an-primary});
-    // color-mix() blends the focus colour with transparent for the glow ring.
-    // Falls back gracefully to the default blue glow in older browsers.
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--an-focus-color, #{$an-primary}) 18%, transparent);
+    // Fallback glow for browsers without color-mix() (pre-Chrome 111, Safari 15.3, Firefox 112).
+    // Uses the static $an-primary value so --an-focus-color overrides are ignored in those browsers.
+    box-shadow: 0 0 0 3px rgba($an-primary, 0.18);
+    // Modern browsers get a fully themeable glow that respects --an-focus-color.
+    @supports (color: color-mix(in srgb, red, blue)) {
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--an-focus-color, #{$an-primary}) 18%, transparent);
+    }
   }
 
   &.an-disabled {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -106,7 +106,7 @@ export interface AsnOptions {
   colorSwatches?: string[];
   /**
    * Display language for the editor UI.
-   * Built-in: 'en' (default) | 'vi' | 'ja' | 'zh' | 'fr'.
+   * Built-in: 'en' (default) | 'vi' | 'ja' | 'zh' | 'fr' | 'de' | 'es' | 'ko'.
    * Pass a partial locale object to override individual strings.
    */
   lang?: string | Partial<AsnLocale>;
@@ -323,7 +323,7 @@ export interface AsnLocale {
   };
 }
 
-/** Registry of all built-in locales (keys: 'en', 'vi', 'ja', 'zh', 'fr'). */
+/** Registry of all built-in locales (keys: 'en', 'vi', 'ja', 'zh', 'fr', 'de', 'es', 'ko'). */
 export declare const locales: Record<string, AsnLocale>;
 
 /**


### PR DESCRIPTION
## Summary

- **publish.yml**: adds `pnpm test` step before npm auth check — prevents publishing broken code; a failing test suite now blocks all three package publishes
- **pages.yml**: adds `pnpm lint` and `pnpm typecheck` steps before `pnpm test:coverage` — the deploy pipeline now gates on lint cleanliness and TypeScript correctness in addition to test pass rate

Both workflows already had `pnpm install`, so no new action references are added (existing `@v4` refs stay untouched — no new SonarCloud security findings expected).

Plan item C3 (partial — standalone `ci.yml` for PR gate still pending due to SHA-pin constraint on new action refs).

## Test plan
- [ ] Push a commit that breaks a test to `main` → publish workflow should fail at "Run tests"
- [ ] Push a commit with a lint error to `main` → pages workflow should fail at "Lint"
- [ ] Green path: normal push → all steps pass, deploy proceeds as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_