### PR TITLE
chore(demo): bump displayed version to v1.8.1

### DIFF
--- a/demo/docs.html
+++ b/demo/docs.html
@@ -251,7 +251,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.0</span>
+      <span class="brand-version">v1.8.1</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>
@@ -318,7 +318,7 @@
   <main class="docs-main" id="docs-main">
 
     <h1 class="page-title">API Reference</h1>
-    <p class="page-sub">AutumnNote v1.8.0 — Fast. Lightweight. Reliable. Efficient.</p>
+    <p class="page-sub">AutumnNote v1.8.1 — Fast. Lightweight. Reliable. Efficient.</p>
 
     <!-- ── Installation ── -->
     <section class="docs-section" id="installation" aria-label="Installation">
@@ -1088,7 +1088,7 @@ console.log(api?.version); // '1.0.0'</code></pre>
 
 <footer class="site-footer">
   <div class="footer-inner">
-    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.0</span>
+    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.1</span>
     <nav class="footer-links" aria-label="Footer links">
       <a href="https://github.com/cmm-cmm/Autumn-Note" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://www.npmjs.com/package/autumnnote" target="_blank" rel="noopener noreferrer">npm</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,7 +39,7 @@
     "operatingSystem": "Web Browser",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "license": "https://opensource.org/licenses/MIT",
-    "softwareVersion": "1.8.0",
+    "softwareVersion": "1.8.1",
     "author": { "@type": "Person", "name": "Minh Pham" },
     "codeRepository": "https://github.com/cmm-cmm/Autumn-Note"
   }
@@ -359,7 +359,7 @@
       <a class="brand" href="https://cmm-cmm.github.io/Autumn-Note/" aria-label="AutumnNote home">
         <img src="/image/banner.png" width="30" height="30" alt="" />
         <span class="brand-name">AutumnNote</span>
-        <span class="brand-version">v1.8.0</span>
+        <span class="brand-version">v1.8.1</span>
       </a>
       <nav class="header-nav" aria-label="Site links">
         <a class="nav-link" href="docs.html">Docs</a>
@@ -372,7 +372,7 @@
 
   <!-- ===================== HERO ===================== -->
   <section class="hero">
-    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.0</span>
+    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.1</span>
     <h1 class="hero-title">Fast. Lightweight.<br>Reliable. Efficient.</h1>
     <p class="hero-sub">
       A modern WYSIWYG editor built with vanilla JavaScript (ES2022+) —

--- a/demo/playground.html
+++ b/demo/playground.html
@@ -382,7 +382,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.0</span>
+      <span class="brand-version">v1.8.1</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>


### PR DESCRIPTION
## Summary
- `package.json` and `CHANGELOG.md` were already at `1.8.1`, but the Live Demo pages (`demo/index.html`, `demo/playground.html`, `demo/docs.html`) still displayed `v1.8.0` in nav badges, the hero tagline, JSON-LD `softwareVersion` metadata, the docs subtitle, and the footer.
- Bumped all "current version" indicators across the three demo pages to `v1.8.1`.
- Left the historical "What's New v1.8.0" feature-changelog section in `docs.html` untouched, since `1.8.1` is a fix-only/CI release with no new features (per `CHANGELOG.md`) — that section correctly documents when those features were introduced.
- `_site/` build artifacts are not committed in this PR; CI's `pages.yml` regenerates `_site` fresh via `npm run build:demo` on every deploy.

## Type of change
- [ ] Bug fix
- [x] Documentation update

## Checklist
- [x] `npm test` passes (1611/1611)
- [x] `npm run build` succeeds
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed (no CHANGELOG entry needed — display-only fix matching already-released version)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_