### PR TITLE
chore(release): sync v1.8.1 demo version bump to main

### DIFF
--- a/demo/docs.html
+++ b/demo/docs.html
@@ -251,7 +251,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.0</span>
+      <span class="brand-version">v1.8.1</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>
@@ -318,7 +318,7 @@
   <main class="docs-main" id="docs-main">
 
     <h1 class="page-title">API Reference</h1>
-    <p class="page-sub">AutumnNote v1.8.0 — Fast. Lightweight. Reliable. Efficient.</p>
+    <p class="page-sub">AutumnNote v1.8.1 — Fast. Lightweight. Reliable. Efficient.</p>
 
     <!-- ── Installation ── -->
     <section class="docs-section" id="installation" aria-label="Installation">
@@ -1088,7 +1088,7 @@ console.log(api?.version); // '1.0.0'</code></pre>
 
 <footer class="site-footer">
   <div class="footer-inner">
-    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.0</span>
+    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.1</span>
     <nav class="footer-links" aria-label="Footer links">
       <a href="https://github.com/cmm-cmm/Autumn-Note" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://www.npmjs.com/package/autumnnote" target="_blank" rel="noopener noreferrer">npm</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,7 +39,7 @@
     "operatingSystem": "Web Browser",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "license": "https://opensource.org/licenses/MIT",
-    "softwareVersion": "1.8.0",
+    "softwareVersion": "1.8.1",
     "author": { "@type": "Person", "name": "Minh Pham" },
     "codeRepository": "https://github.com/cmm-cmm/Autumn-Note"
   }
@@ -359,7 +359,7 @@
       <a class="brand" href="https://cmm-cmm.github.io/Autumn-Note/" aria-label="AutumnNote home">
         <img src="/image/banner.png" width="30" height="30" alt="" />
         <span class="brand-name">AutumnNote</span>
-        <span class="brand-version">v1.8.0</span>
+        <span class="brand-version">v1.8.1</span>
       </a>
       <nav class="header-nav" aria-label="Site links">
         <a class="nav-link" href="docs.html">Docs</a>
@@ -372,7 +372,7 @@
 
   <!-- ===================== HERO ===================== -->
   <section class="hero">
-    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.0</span>
+    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.1</span>
     <h1 class="hero-title">Fast. Lightweight.<br>Reliable. Efficient.</h1>
     <p class="hero-sub">
       A modern WYSIWYG editor built with vanilla JavaScript (ES2022+) —

--- a/demo/playground.html
+++ b/demo/playground.html
@@ -382,7 +382,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.0</span>
+      <span class="brand-version">v1.8.1</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>


### PR DESCRIPTION
## Summary
- Carries `8dc3394` (#46) from `dev` into `main` so the live GitHub Pages demo reflects `v1.8.1` (nav badges, hero tagline, JSON-LD metadata, docs subtitle, footer) instead of the stale `v1.8.0`.
- No source/library code changes — demo-only display text.

## Type of change
- [ ] Bug fix
- [x] Documentation update

## Checklist
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed (no change needed; already reflects 1.8.1)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated displayed product version from **v1.8.0** to **v1.8.1** across the demo site and documentation pages.
  * Refreshed version badges, headings, and footer text so the site now reflects the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->