### PR TITLE
chore(deploy): add Cloudflare Workers static-assets config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 .vite/
 .rollup.cache/
 
+# Wrangler (Cloudflare) local cache
+.wrangler/
+
 # Test coverage
 coverage/
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "autumn-note-demo"
+compatibility_date = "2026-06-30"
+
+[assets]
+directory = "./_site"


### PR DESCRIPTION
## Summary
- Adds `wrangler.toml` so the Cloudflare Workers Builds Git integration can deploy the demo site (`_site`) as a static-assets Worker via `npx wrangler deploy`.
- Adds `.wrangler/` to `.gitignore` (local Wrangler cache dir).
- No source/library code changes — `vite.demo.config.js` already supports `DEMO_BASE_PATH`/`DEMO_OUT_DIR` env vars for non-GitHub-Pages build targets, verified by a local dry-run build + `wrangler deploy --dry-run`.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (deploy config, no behavior change)

## Checklist
- [x] `npm test` passes (1611/1611)
- [x] `npm run build` succeeds
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed (not needed — internal deploy tooling only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_