### PR TITLE
chore(release): sync Cloudflare Workers config to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ dist/
 .vite/
 .rollup.cache/
 
+# Wrangler (Cloudflare) local cache
+.wrangler/
+
 # Test coverage
 coverage/
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "autumn-note-demo"
+compatibility_date = "2026-06-30"
+
+[assets]
+directory = "./_site"


### PR DESCRIPTION
## Summary
- Carries `ce67b76` (#48) from `dev` into `main` so `wrangler.toml` is present when connecting this repo to Cloudflare Workers Builds (Git integration).
- No source/library code changes — adds `wrangler.toml` (static-assets config for the demo build) and a `.gitignore` entry for the local `.wrangler/` cache.

## Type of change
- [ ] Bug fix
- [x] Documentation update

## Checklist
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed (not needed — internal deploy tooling only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_