### PR TITLE
fix(deploy): align wrangler.toml Worker name with Cloudflare project

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "autumn-note-demo"
+name = "autumn-note"
 compatibility_date = "2026-06-30"
 
 [assets]


### PR DESCRIPTION
## Summary
- The first successful Cloudflare Workers Builds deploy logged: `Failed to match Worker name. Your config file is using the Worker name "autumn-note-demo", but the CI system expected "autumn-note". Overriding using the CI provided Worker name. Workers Builds connected builds will attempt to open a pull request to resolve this config name mismatch.`
- Renames `wrangler.toml`'s `name` field from `autumn-note-demo` to `autumn-note` to match the actual Cloudflare project, preempting Cloudflare's own auto-fix PR.

## Type of change
- [x] Bug fix

## Checklist
- [x] `npm test` passes
- [x] `npm run build` succeeds
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed (not needed — internal deploy config only)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_