### PR TITLE
fix(ci): remove perFile coverage enforcement that broke main CI

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,10 +15,6 @@ export default defineConfig({
         statements: 83,
         functions: 80,
         branches: 70,
-        perFile: true,
-        // Per-file floor — lower than aggregate so coverage-sparse files are tracked
-        // without failing the build while still catching complete regressions.
-        '**/*': { lines: 30, statements: 30, functions: 25, branches: 20 },
       },
     },
   },


### PR DESCRIPTION
## Summary
- The `fix(audit)` commit (`d7d44e5`) on `main` added `thresholds.perFile: true` to `vitest.config.js`, intending to add a low per-file safety-net floor via the `'**/*'` glob entry.
- This unintentionally also made the *existing aggregate* thresholds (`lines: 87, statements: 83, functions: 80, branches: 70`) apply to **every individual file** instead of the whole codebase in aggregate.
- ~20 source files that were previously fine in aggregate (overall coverage 87.63% lines / 83.65% stmts / 80.13% funcs / 70.29% branches) failed once enforced per-file, breaking both the `CI` and `Publish to npm` workflows on `main`.
- This PR removes `perFile: true` and the now-unused `'**/*'` floor entry, restoring the original aggregate-only gate that was working before.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] `npm test` passes (1611/1611 tests)
- [x] `pnpm test:coverage` passes (was failing before this fix)
- [x] `npm run build` succeeds
- [x] `npm run lint` / `npm run typecheck` pass
- [x] Code follows the existing style
- [ ] README / CHANGELOG updated if needed (not applicable — internal CI config fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_