### PR TITLE
fix(ci): remove perFile coverage enforcement that broke main CI

### DIFF
--- a/demo/docs.html
+++ b/demo/docs.html
@@ -270,7 +270,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.2</span>
+      <span class="brand-version">v1.8.3</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>
@@ -337,7 +337,7 @@
   <main class="docs-main" id="docs-main">
 
     <h1 class="page-title">API Reference</h1>
-    <p class="page-sub">AutumnNote v1.8.2 — Fast. Lightweight. Reliable. Efficient.</p>
+    <p class="page-sub">AutumnNote v1.8.3 — Fast. Lightweight. Reliable. Efficient.</p>
 
     <!-- ── Installation ── -->
     <section class="docs-section" id="installation" aria-label="Installation">
@@ -1107,7 +1107,7 @@ console.log(api?.version); // '1.0.0'</code></pre>
 
 <footer class="site-footer">
   <div class="footer-inner">
-    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.2</span>
+    <span>MIT License · © 2026 Minh Pham · AutumnNote v1.8.3</span>
     <nav class="footer-links" aria-label="Footer links">
       <a href="https://github.com/cmm-cmm/Autumn-Note" target="_blank" rel="noopener noreferrer">GitHub</a>
       <a href="https://www.npmjs.com/package/autumnnote" target="_blank" rel="noopener noreferrer">npm</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -44,7 +44,7 @@
     "operatingSystem": "Web Browser",
     "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
     "license": "https://opensource.org/licenses/MIT",
-    "softwareVersion": "1.8.2",
+    "softwareVersion": "1.8.3",
     "isAccessibleForFree": true,
     "author": { "@type": "Person", "name": "Minh Pham" },
     "codeRepository": "https://github.com/cmm-cmm/Autumn-Note",
@@ -420,7 +420,7 @@
       <a class="brand" href="https://autumn.konexforge.com/" aria-label="AutumnNote home">
         <img src="/image/banner.png" width="30" height="30" alt="" />
         <span class="brand-name">AutumnNote</span>
-        <span class="brand-version">v1.8.2</span>
+        <span class="brand-version">v1.8.3</span>
       </a>
       <nav class="header-nav" aria-label="Site links">
         <a class="nav-link" href="docs.html">Docs</a>
@@ -433,7 +433,7 @@
 
   <!-- ===================== HERO ===================== -->
   <section class="hero">
-    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.2</span>
+    <span class="hero-eyebrow">Open Source &middot; MIT License &middot; v1.8.3</span>
     <h1 class="hero-title">Fast. Lightweight.<br>Reliable. Efficient.</h1>
     <p class="hero-sub">
       A modern WYSIWYG editor built with vanilla JavaScript (ES2022+) —

--- a/demo/playground.html
+++ b/demo/playground.html
@@ -417,7 +417,7 @@
     <a class="brand" href="./" aria-label="AutumnNote home">
       <img src="/image/banner.png" width="26" height="26" alt="" />
       <span class="brand-name">AutumnNote</span>
-      <span class="brand-version">v1.8.2</span>
+      <span class="brand-version">v1.8.3</span>
     </a>
     <nav class="header-nav" aria-label="Site links">
       <a class="nav-link" href="./">Home</a>

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -15,10 +15,6 @@ export default defineConfig({
         statements: 83,
         functions: 80,
         branches: 70,
-        perFile: true,
-        // Per-file floor — lower than aggregate so coverage-sparse files are tracked
-        // without failing the build while still catching complete regressions.
-        '**/*': { lines: 30, statements: 30, functions: 25, branches: 20 },
       },
     },
   },


### PR DESCRIPTION
## Summary
- `main`'s `CI` and `Publish to npm` workflows have been failing since commit `b7a0a96` (PR #54) due to `vitest.config.js` gaining `thresholds.perFile: true`, which made the aggregate coverage thresholds apply per-file instead of in aggregate, failing ~20 files.
- This release PR ships the fix merged to `dev` in #55: removes `perFile: true` and the now-unused `'**/*'` floor entry, restoring the working aggregate-only gate.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] `npm test` passes (1611/1611 tests)
- [x] `pnpm test:coverage` passes
- [x] `npm run build` succeeds
- [x] `npm run lint` / `npm run typecheck` pass
- [x] Code follows the existing style
- [ ] README / CHANGELOG updated if needed (not applicable — internal CI config fix)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_