### PR TITLE
ci: auto-tag and auto-release on version bump to main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,54 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+  workflow_dispatch: {}
+
+concurrency:
+  group: auto-release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version and tag
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag if missing
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping tag creation."
+          else
+            git tag -a "$TAG" -m "$TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Create GitHub Release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping."
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/auto-release.yml`, triggered on push to `main` when `package.json` changes (plus manual `workflow_dispatch`).
- When the current `package.json` version isn't yet tagged, it creates the annotated git tag and pushes it.
- When no GitHub Release exists for that tag, it creates one (`gh release create --generate-notes`).
- This closes the gap in the existing pipeline: `publish.yml` only runs on `release: published`, but nothing was creating that release automatically after a `dev` → `main` merge — so npm publishing has been a fully manual step since `v1.12.0` (tags existed, but no Releases, so npm was never triggered).
- Both steps are idempotent (skip if the tag/release already exists), so re-runs and pushes that don't bump the version are no-ops.
- Uses the default `GITHUB_TOKEN` (workflow-scoped, `contents: write`) — no new secrets needed. The existing `publish.yml` already uses the separately-configured `NPM_TOKEN` secret for the actual npm publish step.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD change

## Checklist
- [x] YAML syntax validated
- [x] No changes to `src/`, so `npx vitest run` / `pnpm build` are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_