### PR TITLE
chore(release): auto-tag/release workflow — dev → main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,54 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - package.json
+  workflow_dispatch: {}
+
+concurrency:
+  group: auto-release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine version and tag
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag if missing
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping tag creation."
+          else
+            git tag -a "$TAG" -m "$TAG"
+            git push origin "$TAG"
+          fi
+
+      - name: Create GitHub Release if missing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping."
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
## Summary

Release to `main`. Brings PR #90 (already merged into `dev`):

- Adds `.github/workflows/auto-release.yml`: watches `package.json` changes on `main` and, when the current version isn't yet tagged/released, creates the git tag and a GitHub Release for it automatically.
- Closes the gap where `publish.yml` (existing, triggers on `release: published`) had nothing upstream creating that release — so npm publishing has been a manual step since v1.12.0.
- Idempotent: skips tag/release creation if either already exists, so it's safe on repeated pushes.
- Also exposes `workflow_dispatch` so it can be triggered manually for already-tagged-but-not-released versions (e.g. the pending v1.15.0).

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD change

## Checklist
- [x] YAML syntax validated
- [x] CI green on PR #90 (build ubuntu/windows, browser chromium/firefox/webkit, SonarCloud, GitGuardian, Cloudflare)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated release workflow that creates version tags and GitHub Releases when package versions change.
  * Added manual release triggering for on-demand publishing.
  * Release notes are generated automatically when a new release is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->