### PR TITLE
ci: fix npm publish never firing after auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag-and-release:
@@ -43,12 +44,25 @@ jobs:
           fi
 
       - name: Create GitHub Release if missing
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
           else
             gh release create "$TAG" --title "$TAG" --generate-notes
+            echo "created=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # A release created by this workflow's own GITHUB_TOKEN does not
+      # trigger other workflows' `release` events (GitHub's built-in
+      # anti-recursion guard) — explicitly dispatch publish.yml instead,
+      # which IS exempt from that restriction.
+      - name: Trigger npm publish
+        if: steps.release.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,10 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch: {}
 
 concurrency:
-  group: npm-release-${{ github.event.release.tag_name }}
+  group: npm-release
   cancel-in-progress: false
 
 jobs:
@@ -32,6 +33,9 @@ jobs:
       - name: Verify release tag and package versions
         run: |
           TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            TAG="v$(node -p "require('./package.json').version")"
+          fi
           VERSION="${TAG#v}"
           test "$TAG" = "v$VERSION"
           test "$(node -p "require('./package.json').version")" = "$VERSION"


### PR DESCRIPTION
## Summary

`publish.yml` triggers on `release: published`, but the v1.15.0 Release created moments ago by `auto-release.yml` (PR #90/#91, merged) never triggered it. Root cause: `auto-release.yml` creates the release using the workflow's own default `GITHUB_TOKEN` — and per GitHub's built-in anti-recursion guard, events originating from actions taken with `GITHUB_TOKEN` do **not** trigger other workflow runs, except `workflow_dispatch`/`repository_dispatch`, which are explicitly exempt. Confirmed via `mcp__github__actions_list` — `publish.yml` has **zero** runs with `event: release` in its entire history (it only ever ran on the old `push` trigger, before the switch to `release`-only in `86d082d`).

Fix:
- Add `workflow_dispatch` to `publish.yml`'s triggers (kept alongside `release: published`, so a human manually publishing a Release via the UI still works normally — that path isn't GITHUB_TOKEN-originated). Also makes the tag-verification step fall back to `v$(package.json version)` when `github.event.release` is unset (i.e. under `workflow_dispatch`).
- `auto-release.yml` now explicitly runs `gh workflow run publish.yml --ref main` right after creating a release, closing the loop end-to-end without manual intervention going forward.

## Type of change
- [ ] Bug fix (product code)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD fix

## Checklist
- [x] YAML syntax validated for both files
- [x] No `src/` changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_