### PR TITLE
chore(release): fix npm publish trigger — dev → main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag-and-release:
@@ -43,12 +44,25 @@ jobs:
           fi
 
       - name: Create GitHub Release if missing
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.version.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, skipping."
+            echo "created=false" >> "$GITHUB_OUTPUT"
           else
             gh release create "$TAG" --title "$TAG" --generate-notes
+            echo "created=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # A release created by this workflow's own GITHUB_TOKEN does not
+      # trigger other workflows' `release` events (GitHub's built-in
+      # anti-recursion guard) — explicitly dispatch publish.yml instead,
+      # which IS exempt from that restriction.
+      - name: Trigger npm publish
+        if: steps.release.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish.yml --ref main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,10 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch: {}
 
 concurrency:
-  group: npm-release-${{ github.event.release.tag_name }}
+  group: npm-release
   cancel-in-progress: false
 
 jobs:
@@ -32,6 +33,9 @@ jobs:
       - name: Verify release tag and package versions
         run: |
           TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            TAG="v$(node -p "require('./package.json').version")"
+          fi
           VERSION="${TAG#v}"
           test "$TAG" = "v$VERSION"
           test "$(node -p "require('./package.json').version")" = "$VERSION"


### PR DESCRIPTION
## Summary

Release to `main`. Brings PR #92 (already merged into `dev`):

- Fixes `publish.yml` never firing after `auto-release.yml` creates a Release — GitHub's anti-recursion guard blocks `GITHUB_TOKEN`-originated `release:published` events from triggering downstream workflows.
- Adds `workflow_dispatch` to `publish.yml` (exempt from that restriction) with a `package.json`-version fallback for the tag-verification step.
- `auto-release.yml` now explicitly runs `gh workflow run publish.yml --ref main` right after creating a release, closing the automation loop end-to-end for future releases.

## Type of change
- [ ] Bug fix (product code)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD fix

## Checklist
- [x] YAML syntax validated
- [x] CI green on PR #92 (build ubuntu/windows, browser chromium/firefox/webkit, SonarCloud, GitGuardian, Cloudflare)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_