### PR TITLE
fix(ci): run build before test:wrappers in check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:wrappers": "pnpm --filter autumnnote-react test && pnpm --filter autumnnote-vue test",
     "build:wrappers": "pnpm --filter autumnnote-react build && pnpm --filter autumnnote-vue build",
     "check:bundle": "node scripts/check-bundle-size.mjs",
-    "check": "pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm test:wrappers && pnpm build && pnpm check:bundle && pnpm build:demo && pnpm build:wrappers"
+    "check": "pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm build && pnpm test:wrappers && pnpm check:bundle && pnpm build:demo && pnpm build:wrappers"
   },
   "keywords": [
     "wysiwyg",


### PR DESCRIPTION
## Summary

The manually-triggered `publish.yml` run for v1.15.0 failed at "Run release checks" (`pnpm check`), before ever reaching the npm auth/publish steps. Root cause: the `check` script in `package.json` ran `test:wrappers` **before** `build`:

```
lint && typecheck && test:coverage && test:wrappers && build && check:bundle && build:demo && build:wrappers
```

`test:wrappers` runs the React/Vue wrapper packages' own test suites, which `import AutumnNote from 'autumnnote'` — resolved via the pnpm workspace link to the root package. On a clean CI checkout (`actions/checkout` + `pnpm install --frozen-lockfile`, no pre-existing `dist/`), that import fails because `dist/autumnnote.es.js` doesn't exist yet — `build` hadn't run.

Locally this was masked because my working copy already had a built `dist/` from earlier manual runs in this session, so I never hit this before triggering `publish.yml` on a genuinely clean CI runner.

Fix: swap the order so `build` runs before `test:wrappers`:
```
lint && typecheck && test:coverage && build && test:wrappers && check:bundle && build:demo && build:wrappers
```

Verified locally by deleting `dist/`, `packages/react/dist/`, `packages/vue/dist/`, and running `pnpm check` end-to-end on the fixed order — passes cleanly (1792/1792 core tests, 3/3 React tests, 2/2 Vue tests, bundle size within budget, demo + wrapper builds all succeed).

## Type of change
- [ ] Bug fix (product code)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD fix

## Checklist
- [x] `pnpm check` passes end-to-end on a clean `dist/` (simulating CI)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_