### PR TITLE
chore(release): fix check script order — dev → main

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:wrappers": "pnpm --filter autumnnote-react test && pnpm --filter autumnnote-vue test",
     "build:wrappers": "pnpm --filter autumnnote-react build && pnpm --filter autumnnote-vue build",
     "check:bundle": "node scripts/check-bundle-size.mjs",
-    "check": "pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm test:wrappers && pnpm build && pnpm check:bundle && pnpm build:demo && pnpm build:wrappers"
+    "check": "pnpm lint && pnpm typecheck && pnpm test:coverage && pnpm build && pnpm test:wrappers && pnpm check:bundle && pnpm build:demo && pnpm build:wrappers"
   },
   "keywords": [
     "wysiwyg",


### PR DESCRIPTION
## Summary

Release to `main`. Brings PR #94 (already merged into `dev`):

- Fixes the `check` npm script order: `build` now runs before `test:wrappers`, so the React/Vue wrapper packages' tests can resolve `import AutumnNote from 'autumnnote'` on a clean checkout (no pre-existing `dist/`).
- This was the actual root cause of `publish.yml`'s v1.15.0 publish attempt failing at the "Run release checks" step, before ever reaching npm auth/publish.
- Verified locally end-to-end with `dist/` deleted, simulating a clean CI checkout.

## Type of change
- [ ] Bug fix (product code)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD fix

## Checklist
- [x] `pnpm check` passes end-to-end on a clean `dist/`
- [x] CI green on PR #94

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the validation workflow to complete the build before running wrapper tests.
  * Other verification steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->