### PR TITLE
ci: migrate npm publish to trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
   publish:
     needs: browser-smoke
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -62,6 +65,11 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
           cache: pnpm
+
+      # Trusted publishing (OIDC) requires npm CLI 11.5.1+; Node 22's
+      # bundled npm may be older, so upgrade explicitly.
+      - name: Ensure npm CLI supports trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -90,16 +98,6 @@ jobs:
           npm pack ./packages/react --dry-run --ignore-scripts
           npm pack ./packages/vue --dry-run --ignore-scripts
 
-      - name: Verify npm auth
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::NPM_TOKEN secret is not set. Go to GitHub → Settings → Secrets → Actions and add NPM_TOKEN with a valid npm access token."
-            exit 1
-          fi
-          npm whoami || { echo "::error::npm token is invalid or expired. Regenerate it at https://www.npmjs.com/settings/<user>/tokens and update the NPM_TOKEN secret."; exit 1; }
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       # ──────────────────────────────────────────────────────────────
       # autumnnote (core)
       # ──────────────────────────────────────────────────────────────
@@ -119,8 +117,6 @@ jobs:
       - name: Publish autumnnote
         if: steps.core_check.outputs.should_publish == 'true'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip autumnnote
         if: steps.core_check.outputs.should_publish == 'false'
@@ -147,8 +143,6 @@ jobs:
       - name: Publish autumnnote-react
         if: steps.react_check.outputs.should_publish == 'true'
         run: pnpm --filter autumnnote-react publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip autumnnote-react
         if: steps.react_check.outputs.should_publish == 'false'
@@ -175,8 +169,6 @@ jobs:
       - name: Publish autumnnote-vue
         if: steps.vue_check.outputs.should_publish == 'true'
         run: pnpm --filter autumnnote-vue publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip autumnnote-vue
         if: steps.vue_check.outputs.should_publish == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify release tag and package versions
+        env:
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG_NAME"
           if [ -z "$TAG" ]; then
             TAG="v$(node -p "require('./package.json').version")"
           fi


### PR DESCRIPTION
## Summary

`NPM_TOKEN` has been removed from repo secrets in favor of npm's [trusted publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC). Updates `publish.yml` accordingly:

- Adds `permissions: { contents: read, id-token: write }` to the `publish` job — required for GitHub Actions to mint the OIDC token npm exchanges for a short-lived publish credential.
- Adds an explicit `npm install -g npm@latest` step after Node setup — trusted publishing requires npm CLI **≥ 11.5.1**, and the npm version bundled with `actions/setup-node`'s Node 22 isn't guaranteed to meet that.
- Removes the `Verify npm auth` step and all `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env blocks — meaningless now that there's no persistent token to check; auth happens transactionally per `npm publish`/`pnpm publish` call via OIDC.
- `pnpm` stays pinned at `11.1.3` — confirmed this version already ships the fix for pnpm's OIDC auth-fallback bug ([pnpm#11513](https://github.com/pnpm/pnpm/issues/11513), fixed in [pnpm#11526](https://github.com/pnpm/pnpm/pull/11526)), so the `autumnnote-react`/`autumnnote-vue` publishes via `pnpm --filter ... publish` don't need to switch to plain `npm publish`.

**Prerequisite (already done):** a trusted publisher must be configured on npmjs.com for each package (`autumnnote`, `autumnnote-react`, `autumnnote-vue`) pointing at `cmm-cmm/Autumn-Note` + workflow file `.github/workflows/publish.yml`.

## Type of change
- [ ] Bug fix (product code)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] CI/CD change

## Checklist
- [x] YAML syntax validated
- [x] `pnpm check` passes end-to-end
- [x] No `NPM_TOKEN`/`NODE_AUTH_TOKEN` references remain anywhere in the repo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_