### PR TITLE
ci: bump all GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,16 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           # Full history so SonarCloud can compute blame / new-code analysis.
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -45,7 +45,7 @@ jobs:
 
       - name: SonarCloud scan
         if: runner.os == 'Linux' && env.SONAR_TOKEN != ''
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ env.SONAR_TOKEN }}
           SONAR_HOST_URL: https://sonarcloud.io
@@ -83,11 +83,11 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -95,7 +95,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,11 +16,11 @@ jobs:
         browser: [chromium, firefox, webkit]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -28,7 +28,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ matrix.browser }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -53,14 +53,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 11.1.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
The v2.1.0 publish run warned that `actions/cache@v4` and `pnpm/action-setup@v4` target Node 20 and are being force-run on Node 24. That fallback is going away, so both had to move; `checkout`, `setup-node` and the Sonar scanner were also two or three majors behind, so they go with them.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v5 | **v7** |
| `actions/setup-node` | v5 | **v7** |
| `actions/cache` | v4 | **v6** |
| `pnpm/action-setup` | v4 | **v6** |
| `SonarSource/sonarqube-scan-action` | v5 | **v8** |

## Breaking changes checked against actual usage

None of them are touched by these workflows:

- **setup-node v6** stopped auto-detecting the package manager and limits automatic caching to npm. Every call site sets `cache: pnpm` explicitly, which still works. `always-auth` (removed in v6) is not used.
- **checkout v7** blocks checking out fork PRs under `pull_request_target` and `workflow_run`. Neither trigger appears here.
- **sonarqube-scan-action v6** reparses the `args` input to prevent command injection — we pass no `args`. **v8** enables scanner signature verification by default, which is desirable.
- **cache v5** requires runner >= 2.327.1, satisfied by GitHub-hosted runners.
- **pnpm/action-setup v6** adds pnpm v11 support, matching the 11.1.3 this repo pins.

CI on this PR is the verification — it exercises checkout, pnpm setup, setup-node with pnpm cache, the cache action and the Sonar scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated release, continuous integration, and publishing workflows to use newer action versions.
  * Improved the reliability and maintainability of automated build, test, scanning, caching, and publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->