### PR TITLE
fix: accept both npm pack --json shapes so v2.2.0 can publish

### DIFF
--- a/scripts/check-package-files.mjs
+++ b/scripts/check-package-files.mjs
@@ -9,24 +9,36 @@
  *
  * So: list the tarball, then walk each shipped JS file's relative imports and
  * assert the target is shipped too.
+ *
+ * The pure helpers are exported for `test/scripts/check-package-files.test.js`;
+ * the npm invocation only runs when this file is executed directly.
  */
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join, normalize } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const raw = execFileSync(
-  'npm',
-  ['pack', '--dry-run', '--ignore-scripts', '--json'],
-  { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
-);
-
-/** @type {string[]} POSIX-style paths, relative to the package root. */
-const shipped = JSON.parse(raw)[0].files.map((f) => f.path);
-const shippedSet = new Set(shipped);
-
-// Only source files can carry unresolvable relative imports; dist bundles are
-// self-contained by construction and their chunk graph is Vite's problem.
-const sources = shipped.filter((f) => f.startsWith('src/') && f.endsWith('.js'));
+/**
+ * `npm pack --json` has two shapes in the wild, and this repo hits both: CI runs
+ * the npm bundled with Node 22 (v10, a top-level array), while the publish job
+ * upgrades to npm@latest for trusted publishing (v12, an object keyed by package
+ * name). Accept either, and fail with something readable if a future npm invents
+ * a third — indexing `[0]` blindly died with "Cannot read properties of
+ * undefined" partway through a release.
+ * @param {string} json
+ * @returns {{ path: string }[]}
+ */
+export function packedFiles(json) {
+  const parsed = JSON.parse(json);
+  const entry = Array.isArray(parsed) ? parsed[0] : Object.values(parsed ?? {})[0];
+  if (!entry || !Array.isArray(entry.files)) {
+    throw new Error(
+      'Unrecognised `npm pack --json` output: expected an array of results or an '
+      + `object keyed by package name, each carrying a "files" array. Got: ${json.slice(0, 200)}`,
+    );
+  }
+  return entry.files;
+}
 
 // `from './x.js'` / `import './x.js'` / `import('./x.js')` — relative only.
 //
@@ -43,27 +55,63 @@ const IMPORT_RE = /(?:\bfrom|\bimport)\s*(?:\(\s*)?['"](\.[^'"]*)['"]/g;
  * TypeScript's own `.js` -> `.d.ts` mapping and never hit the module loader.
  * Block comments go first; line comments only when the line is wholly a comment,
  * which leaves `https://` inside string literals alone.
+ * @param {string} code
+ * @returns {string}
  */
-const stripComments = (code) => code
+export const stripComments = (code) => code
   .replace(/\/\*[\s\S]*?\*\//g, '')
   .replace(/^\s*\/\/.*$/gm, '');
 
-let failed = false;
-for (const file of sources) {
-  const code = stripComments(readFileSync(file, 'utf8'));
-  for (const [, specifier] of code.matchAll(IMPORT_RE)) {
-    const target = normalize(join(dirname(file), specifier)).replaceAll('\\', '/');
-    if (shippedSet.has(target)) continue;
-    console.error(
-      `::error file=${file}::imports "${specifier}" -> "${target}", which package.json#files does not ship. `
-      + 'Add it to "files" or drop the import.',
-    );
-    failed = true;
+/**
+ * Relative import specifiers in `code`, resolved against `file`'s directory and
+ * normalised to POSIX separators so they can be compared to tarball paths.
+ * @param {string} file - repo-relative path of the file `code` came from
+ * @param {string} code
+ * @returns {{ specifier: string, target: string }[]}
+ */
+export function resolvedImports(file, code) {
+  const out = [];
+  for (const [, specifier] of stripComments(code).matchAll(IMPORT_RE)) {
+    out.push({
+      specifier,
+      target: normalize(join(dirname(file), specifier)).replaceAll('\\', '/'),
+    });
+  }
+  return out;
+}
+
+function main() {
+  const raw = execFileSync(
+    'npm',
+    ['pack', '--dry-run', '--ignore-scripts', '--json'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+  );
+
+  /** @type {string[]} POSIX-style paths, relative to the package root. */
+  const shipped = packedFiles(raw).map((f) => f.path);
+  const shippedSet = new Set(shipped);
+
+  // Only source files can carry unresolvable relative imports; dist bundles are
+  // self-contained by construction and their chunk graph is Vite's problem.
+  const sources = shipped.filter((f) => f.startsWith('src/') && f.endsWith('.js'));
+
+  let failed = false;
+  for (const file of sources) {
+    for (const { specifier, target } of resolvedImports(file, readFileSync(file, 'utf8'))) {
+      if (shippedSet.has(target)) continue;
+      console.error(
+        `::error file=${file}::imports "${specifier}" -> "${target}", which package.json#files does not ship. `
+        + 'Add it to "files" or drop the import.',
+      );
+      failed = true;
+    }
+  }
+
+  if (failed) {
+    process.exitCode = 1;
+  } else {
+    console.log(`Package is self-contained: ${sources.length} shipped source files, all relative imports resolve.`);
   }
 }
 
-if (failed) {
-  process.exitCode = 1;
-} else {
-  console.log(`Package is self-contained: ${sources.length} shipped source files, all relative imports resolve.`);
-}
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) main();

--- a/test/scripts/check-package-files.test.js
+++ b/test/scripts/check-package-files.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { packedFiles, resolvedImports, stripComments } from '../../scripts/check-package-files.mjs';
+
+describe('packedFiles', () => {
+  const files = [{ path: 'dist/index.js' }, { path: 'src/js/i18n/vi.js' }];
+
+  it('reads the array shape npm 10 emits', () => {
+    expect(packedFiles(JSON.stringify([{ name: 'autumnnote', files }]))).toEqual(files);
+  });
+
+  it('reads the name-keyed object shape npm 12 emits', () => {
+    // The publish job installs npm@latest for trusted publishing, so the two
+    // shapes coexist in this repo's CI. Assuming the array shape once broke a
+    // release partway through `pnpm check`.
+    expect(packedFiles(JSON.stringify({ autumnnote: { name: 'autumnnote', files } }))).toEqual(files);
+  });
+
+  it.each([
+    ['empty object', '{}'],
+    ['empty array', '[]'],
+    ['null', 'null'],
+    ['entry without files', '{"autumnnote":{"name":"autumnnote"}}'],
+    ['files not an array', '{"autumnnote":{"files":"nope"}}'],
+  ])('throws a diagnosable error on %s rather than a TypeError', (_label, json) => {
+    expect(() => packedFiles(json)).toThrow(/Unrecognised `npm pack --json` output/);
+  });
+});
+
+describe('stripComments', () => {
+  it('drops JSDoc type imports so they are not mistaken for runtime imports', () => {
+    const code = "/** @type {import('../../types/index.js')} */\nexport const x = 1;";
+    expect(stripComments(code)).not.toContain('types/index.js');
+  });
+
+  it('drops whole-line comments but leaves protocol slashes inside strings alone', () => {
+    const code = "// import './ignored.js';\nconst url = 'https://example.com/a';";
+    const out = stripComments(code);
+    expect(out).not.toContain('ignored.js');
+    expect(out).toContain('https://example.com/a');
+  });
+});
+
+describe('resolvedImports', () => {
+  it('resolves every import spelling against the importing file directory', () => {
+    const code = [
+      "import { a } from './a.js';",
+      "import './b.js';",
+      "import('./c.js');",
+      "import( './d.js' );",
+      "import   './e.js';",
+      'export { f } from "../f.js";',
+    ].join('\n');
+
+    expect(resolvedImports('src/js/i18n/index.js', code).map((i) => i.target)).toEqual([
+      'src/js/i18n/a.js',
+      'src/js/i18n/b.js',
+      'src/js/i18n/c.js',
+      'src/js/i18n/d.js',
+      'src/js/i18n/e.js',
+      'src/js/f.js',
+    ]);
+  });
+
+  it('ignores bare specifiers, which the package manager resolves', () => {
+    expect(resolvedImports('src/js/a.js', "import x from 'lodash';")).toEqual([]);
+  });
+
+  it('reports the raw specifier alongside the resolved target', () => {
+    expect(resolvedImports('src/js/i18n/index.js', "import { m } from '../core/func.js';")).toEqual([
+      { specifier: '../core/func.js', target: 'src/js/core/func.js' },
+    ]);
+  });
+
+  it('matches a long non-matching whitespace run without backtracking', () => {
+    // Guards the CWE-1333 fix: two adjacent `\s*` used to make this super-linear.
+    const evil = `import${' '.repeat(50_000)}x`;
+    const start = performance.now();
+    resolvedImports('src/js/a.js', evil);
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
+});


### PR DESCRIPTION
## Summary

Unblocks the v2.2.0 npm publish. The tag and GitHub release for `v2.2.0` already exist; the publish job failed before anything reached npm, so nothing is half-released.

`scripts/check-package-files.mjs` (added in #102) indexed `npm pack --json` output as `[0]`. That is the npm 10 shape. The publish job runs `npm install -g npm@latest` first — required for OIDC trusted publishing — and **npm 12 returns an object keyed by package name** instead. The scanner threw `TypeError: Cannot read properties of undefined (reading 'files')`, failing `pnpm check` at the "Run release checks" step.

CI never caught this because the `build` job uses the npm bundled with Node 22, which is still v10 and still the array shape. Only the publish job upgrades, so the two shapes coexist in this repo and the check only ever saw one of them.

## Changes

- `packedFiles()` accepts the array shape and the name-keyed object shape, and throws with the offending payload if npm ever emits a third — a diagnosable message instead of a `TypeError` mid-release.
- Pure helpers (`packedFiles`, `stripComments`, `resolvedImports`) are exported; the npm invocation now runs only when the file is executed directly, so tests can import it without shelling out.
- New `test/scripts/check-package-files.test.js` — 13 tests covering both shapes, five malformed payloads, all six import spellings, comment stripping, and the non-backtracking guarantee on the import regex.

Verified locally against both npm 10 (Node 22 bundled) and npm 12 (`npm@latest`, as the publish job runs it); full `pnpm check` is green.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] `npm test` passes — 1952 tests
- [x] `npm run build` succeeds — full `pnpm check` green
- [x] Code follows the existing style
- [x] README / CHANGELOG updated if needed — internal tooling fix, no consumer-facing change

After merge, `publish.yml` needs a manual `workflow_dispatch` on `main`: `auto-release.yml` only fires on `package.json` changes and the `v2.2.0` release already exists, so it will not re-trigger on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eb4mZXXbaoq8jjDJ8DErJA)_